### PR TITLE
add option 'r'

### DIFF
--- a/05.ls/ls_command.rb
+++ b/05.ls/ls_command.rb
@@ -10,10 +10,19 @@ opts.on('-r') { params[:r] = true }
 opts.parse!(ARGV)
 
 def file_in_current_dir(option)
-  if option[:a]
-    Dir.glob('*', File::FNM_DOTMATCH)
-  elsif option[:r]
-    Dir.glob('*').reverse
+  case option.size
+  when 1
+    if option[:a]
+      Dir.glob('*', File::FNM_DOTMATCH)
+    elsif option[:r]
+      Dir.glob('*').reverse
+    else
+      raise "ls: illegal option -- #{option.keys}"
+    end
+  when 2
+    raise "ls: illegal option -- #{option.keys}" unless option[:a] && option[:r]
+
+    Dir.glob('*', File::FNM_DOTMATCH).reverse
   else
     Dir.glob('*')
   end

--- a/05.ls/ls_command.rb
+++ b/05.ls/ls_command.rb
@@ -10,21 +10,16 @@ opts.on('-r') { params[:r] = true }
 opts.parse!(ARGV)
 
 def file_in_current_dir(option)
-  case option.size
-  when 1
-    if option[:a]
-      Dir.glob('*', File::FNM_DOTMATCH)
-    elsif option[:r]
-      Dir.glob('*').reverse
-    else
-      raise "ls: illegal option -- #{option.keys}"
-    end
-  when 2
-    raise "ls: illegal option -- #{option.keys}" unless option[:a] && option[:r]
-
+  if option[:a] && option[:r]
     Dir.glob('*', File::FNM_DOTMATCH).reverse
-  else
+  elsif option[:a]
+    Dir.glob('*', File::FNM_DOTMATCH)
+  elsif option[:r]
+    Dir.glob('*').reverse
+  elsif option.empty?
     Dir.glob('*')
+  else
+    raise "ls: illegal option -- #{option.keys}"
   end
 end
 

--- a/05.ls/ls_command.rb
+++ b/05.ls/ls_command.rb
@@ -6,15 +6,17 @@ require 'optparse'
 params = {}
 opts = OptionParser.new
 opts.on('-a') { params[:a] = true }
+opts.on('-r') { params[:r] = true }
 opts.parse!(ARGV)
 
-def file_in_current_dir(option_a)
-  list = if option_a
-           Dir.glob('*', File::FNM_DOTMATCH)
-         else
-           Dir.glob('*')
-         end
-  list.sort
+def file_in_current_dir(option)
+  if option[:a]
+    Dir.glob('*', File::FNM_DOTMATCH)
+  elsif option[:r]
+    Dir.glob('*').reverse
+  else
+    Dir.glob('*')
+  end
 end
 
 def format_list(list, max_column)
@@ -27,5 +29,5 @@ def format_list(list, max_column)
 end
 
 max_column = 3
-files = file_in_current_dir(params[:a])
+files = file_in_current_dir(params)
 format_list(files, max_column)

--- a/05.ls/ls_command.rb
+++ b/05.ls/ls_command.rb
@@ -9,18 +9,22 @@ opts.on('-a') { params[:a] = true }
 opts.on('-r') { params[:r] = true }
 opts.parse!(ARGV)
 
-def file_in_current_dir(option)
-  if option[:a] && option[:r]
-    Dir.glob('*', File::FNM_DOTMATCH).reverse
-  elsif option[:a]
-    Dir.glob('*', File::FNM_DOTMATCH)
-  elsif option[:r]
-    Dir.glob('*').reverse
-  elsif option.empty?
-    Dir.glob('*')
-  else
-    raise "ls: illegal option -- #{option.keys}"
+def file_in_current_dir(options)
+  files = Dir.glob('*')
+  return files if options.empty?
+
+  options = options.sort.to_h
+  options.each_key do |option|
+    case option
+    when :a
+      files = Dir.glob('*', File::FNM_DOTMATCH)
+    when :r
+      files = files.reverse
+    else
+      raise "ls: illegal option -- #{option}"
+    end
   end
+  files
 end
 
 def format_list(list, max_column)


### PR DESCRIPTION
lsコマンドにrオプション追加しました。

# 実行結果
```bash
🍒05.ls$ ruby ls_command.rb
1_test.txt	2_test.txt	ls_command.rb

🍒05.ls$ ruby ls_command.rb -a
.	.gitkeep	2_test.txt
..	1_test.txt	ls_command.rb

🍒05.ls$ ruby ls_command.rb -r
ls_command.rb	2_test.txt	1_test.txt

🍒05.ls$ ls -r
ls_command.rb	2_test.txt	1_test.txt

🍒05.ls$ ruby ls_command.rb -a -r
ls_command.rb	1_test.txt	..
2_test.txt	.gitkeep	.

🍒05.ls$ ls -a -r
ls_command.rb	1_test.txt	..
2_test.txt	.gitkeep	.
```
# rubocop
![image](https://user-images.githubusercontent.com/43959158/145214985-db9e1b91-5eea-42b6-9735-0a60b91e00ba.png)
